### PR TITLE
moved configuration to sales tab

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="splab" translate="label" sortOrder="10">
-            <label>SP</label>
-         </tab>
          <section id="orderattachments" translate="label" type="text" sortOrder="1566" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
             <label>Order Attachments</label>
-            <tab>splab</tab>
+            <tab>sales</tab>
             <resource>Sp_Orderattachments::config</resource>
             <group id="general" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General</label>


### PR DESCRIPTION
Configuration should reside under the existing tabs if possible. See https://devdocs.magento.com/guides/v2.3/ext-best-practices/admin/placement-and-design.html as a reference.