### PR TITLE
Fix 2.4 compatibility

### DIFF
--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -6,10 +6,10 @@
     <update handle="editor"/>
     <body>
         <referenceBlock name="sales_order_tabs">
-            <block class="Sp\Orderattachment\Block\Adminhtml\Order\View\Tab\Attachments" name="sales.order.view.tab.attachment" as="sp.attachments" template="order/view/tab/attachments.phtml"/>
+            <block class="Sp\Orderattachment\Block\Adminhtml\Order\View\Tab\Attachments" name="sales.order.view.tab.attachment" as="sp_attachments" template="order/view/tab/attachments.phtml"/>
             <action method="addTab">
-                <argument name="name" xsi:type="string">sp.attachments</argument>
-                <argument name="block" xsi:type="string">sp.attachments</argument>
+                <argument name="name" xsi:type="string">sp_attachments</argument>
+                <argument name="block" xsi:type="string">sp_attachments</argument>
             </action>
         </referenceBlock>
     </body>


### PR DESCRIPTION
Magento 2.4 now uses the tab ID to reference the tab via a jQuery selector and un-hides the tab then:

https://github.com/magento/magento2/blob/f6491847d053a25d401bf6f9e5c1a84f787c5c06/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml#L90-L92

This fails if a dot is used in the tab ID. Using an underscore works flawlessly.